### PR TITLE
Add "remote_include_output" option to Runner context. This flags tell…

### DIFF
--- a/src/nnsight/pydantics/Request.py
+++ b/src/nnsight/pydantics/Request.py
@@ -17,6 +17,7 @@ class RequestModel(BaseModel):
     session_id: str = None
     received: datetime = None
     blocking: bool = False
+    include_output: bool = False
 
     @field_serializer("intervention_graph")
     def intervention_graph_serialize(self, value, _info) -> bytes:


### PR DESCRIPTION
…s the server whether to include the output in the response. Off by default