### PR TITLE
            # Arguments might be tensors created outside of scanning.…

### DIFF
--- a/src/nnsight/tracing/Graph.py
+++ b/src/nnsight/tracing/Graph.py
@@ -5,7 +5,7 @@ import weakref
 from typing import Any, Callable, Dict, List, Type, Union
 
 import torch
-from torch._subclasses.fake_tensor import FakeTensorMode
+from torch._subclasses.fake_tensor import FakeCopyMode, FakeTensorMode
 from torch.fx.experimental.symbolic_shapes import ShapeEnv
 
 from .. import util
@@ -141,17 +141,12 @@ class Graph:
                 allow_non_fake_inputs=True,
                 shape_env=ShapeEnv(assume_static_by_default=True),
             ) as fake_mode:
-
-                try:
-
+                with FakeCopyMode(fake_mode):
+                    
                     value = target(
                         *Node.prepare_proxy_values(_args),
                         **Node.prepare_proxy_values(_kwargs),
                     )
-
-                except RuntimeError:
-
-                    value = None
 
         target_name = target if isinstance(target, str) else target.__name__
 


### PR DESCRIPTION
… Also the model might be a 'meta' pre-dispatched version of the model.

            # That means the tensors as args and the model are different devices but we dont want to have to have the users move tensors to 'meta'
            # So only when theres a FakeTensor with device meta, we move other tensors also to meta.

 The error is that youre using tensors on device cuda:0, but the scanned proxy values underlying the first trace is on device 'meta' because you prob dont have dispatch=True? meaning the model is only loaded after the first trace and then has cuda:0 as its parameters so then the error does not happen.

So when I prepare the values before "validating" each operations you do in the tracing context, I'll check for FakeTensors, if theres one on device meta, I'll move a copy of any tensors that interact with them also to meta