### PR TITLE
If theres no scanned in value for a Proxy and .shape,  .dtype, or .de…

### DIFF
--- a/src/nnsight/intervention.py
+++ b/src/nnsight/intervention.py
@@ -162,6 +162,11 @@ class InterventionProxy(Proxy):
         if not self.node.is_tracing():
 
             return util.apply(self.value, lambda x: x.shape, torch.Tensor)
+        
+        # If we haven't scanned in a proxy_value, just return a proxy to get the attribute.
+        if self.node.proxy_value is None:
+            
+            return super().__getattr__('shape')
 
         return util.apply(self.node.proxy_value, lambda x: x.shape, torch.Tensor)
 
@@ -176,6 +181,11 @@ class InterventionProxy(Proxy):
         if not self.node.is_tracing():
 
             return util.apply(self.value, lambda x: x.device, torch.Tensor)
+        
+        # If we haven't scanned in a proxy_value, just return a proxy to get the attribute.
+        if self.node.proxy_value is None:
+            
+            return super().__getattr__('device')
 
         return util.apply(self.node.proxy_value, lambda x: x.device, torch.Tensor)
 
@@ -190,6 +200,11 @@ class InterventionProxy(Proxy):
         if not self.node.is_tracing():
 
             return util.apply(self.value, lambda x: x.dtype, torch.Tensor)
+        
+        # If we haven't scanned in a proxy_value, just return a proxy to get the attribute.
+        if self.node.proxy_value is None:
+            
+            return super().__getattr__('dtype')
 
         return util.apply(self.node.proxy_value, lambda x: x.dtype, torch.Tensor)
 


### PR DESCRIPTION
…vice is called on it, return a Proxy of the operation, not the actual attribute on the proxy_value